### PR TITLE
Changed html dir to docs

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -56,7 +56,7 @@
 
     // The directory (relative to the current directory) that the html tree
     // should be written to.  If not provided, defaults to "html".
-    "html_dir": "html",
+    "html_dir": "docs",
 
     // The number of characters to retain in the commit hashes.
     "hash_length": 8,


### PR DESCRIPTION
Changed the html folder name to `docs` so that it is easy to deploy the benchmarks on github pages.