### PR TITLE
Upgrade dependencies and tooling versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,11 +22,11 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
-          python-version: 3.8
+          python-version: "3.12"
       - name: install and test
         run: |
           pip install .
-          asv check
+          asv check --python same

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version.
-    rev: 'v0.0.280'
+    rev: 'v0.15.4'
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -36,7 +36,7 @@
     //
     "matrix": {
         "osqp": [],
-        "ecos": [],
+        "clarabel": [],
         "scs": [],
         "numpy": [],
         "scipy": [],

--- a/backends/dpp_canonicalization.py
+++ b/backends/dpp_canonicalization.py
@@ -42,9 +42,8 @@ import time
 from dataclasses import dataclass, field
 from typing import Callable
 
-import numpy as np
-
 import cvxpy as cp
+import numpy as np
 
 # Optional imports
 try:
@@ -1184,8 +1183,12 @@ def main():
         profile_problems = {
             "dpp_lasso_small": ("DPP LASSO (50x100)", make_dpp_lasso(50, 100)),
             "dpp_lasso_medium": ("DPP LASSO (200x500)", make_dpp_lasso(200, 500)),
-            "dpp_constraint_medium": ("DPP Constraint (500x200)", make_dpp_constraint_matrix(200, 500)),
-            "dpp_constraint_large": ("DPP Constraint (1000x500)", make_dpp_constraint_matrix(500, 1000)),
+            "dpp_constraint_medium": (
+                "DPP Constraint (500x200)", make_dpp_constraint_matrix(200, 500)
+            ),
+            "dpp_constraint_large": (
+                "DPP Constraint (1000x500)", make_dpp_constraint_matrix(500, 1000)
+            ),
         }
         if args.profile in profile_problems:
             name, factory = profile_problems[args.profile]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,4 @@
 [tool.ruff]
-select = ["E", "F", "I"]
 line-length = 100
 exclude = [
     "build",
@@ -7,7 +6,10 @@ exclude = [
     "*__init__.py"
 ]
 # The minimum Python version that should be supported
-target-version = "py37"
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
 
 [build-system]
 requires = ["setuptools>=42"]

--- a/setup.py
+++ b/setup.py
@@ -15,11 +15,11 @@ setuptools.setup(
     },
     package_dir={"": "benchmark"},
     packages=setuptools.find_packages(where="benchmark"),
-    python_requires=">=3.7",
+    python_requires=">=3.11",
     license='Apache License, Version 2.0',
     install_requires=[
         "cvxpy",
-        "asv<0.6",
+        "asv<0.7",
         "virtualenv",
         "clarabel",
         "scs",


### PR DESCRIPTION
## Summary
- Bump Python minimum to 3.11 (matching current cvxpy requirements)
- Update ruff `v0.0.280` → `v0.15.4`, migrate to `ruff-check` hook and `[tool.ruff.lint]` config
- Update `actions/checkout` and `actions/setup-python` `v2` → `v6`
- Bump CI Python from 3.8 to 3.12
- Unpin `asv<0.6` → `asv<0.7`
- Replace `ecos` with `clarabel` in asv matrix (ecos is deprecated in cvxpy)

## Test plan
- [ ] CI passes with updated actions and Python version
- [ ] `asv check --python same` succeeds with the new asv version
- [ ] Pre-commit ruff-check hook works with the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)