### PR TITLE
Seed RNG in the remaining unseeded benchmark setups

### DIFF
--- a/benchmark/matrix_stuffing.py
+++ b/benchmark/matrix_stuffing.py
@@ -21,6 +21,7 @@ class ConeMatrixStuffingBench:
     def setup(self):
         m = 5000
         n = 5000
+        np.random.seed(0)
         A = np.random.randn(m, n)
         C = np.random.rand(m // 2)
         b = np.random.randn(m)
@@ -44,6 +45,7 @@ class ParamConeMatrixStuffing:
     def setup(self):
         m = 200
         n = 200
+        np.random.seed(0)
         A = cp.Parameter((m, n))
         C = cp.Parameter(m // 2)
         b = cp.Parameter(m)
@@ -70,6 +72,7 @@ class SmallMatrixStuffing:
     def setup(self):
         m = 4000
         n = 4000
+        np.random.seed(0)
         A = np.random.randn(m, n)
         C = np.random.rand(m // 2)
         b = np.random.randn(m)
@@ -93,6 +96,7 @@ class ParamSmallMatrixStuffing:
     def setup(self):
         m = 300
         n = 300
+        np.random.seed(0)
         A = cp.Parameter((m, n))
         C = cp.Parameter(m // 2)
         b = cp.Parameter(m)

--- a/benchmark/simple_QP_benchmarks.py
+++ b/benchmark/simple_QP_benchmarks.py
@@ -85,6 +85,7 @@ class UnconstrainedQP:
         N_t = 2
         N_s = 7
 
+        np.random.seed(0)
         x = np.random.randint(2, size=N_s * N_r * N_t)
 
         H = dft(N_s * N_r * N_t) * 1j

--- a/benchmark/tv_inpainting.py
+++ b/benchmark/tv_inpainting.py
@@ -18,6 +18,7 @@ import numpy as np
 class TvInpainting:
 
     def setup(self):
+        np.random.seed(0)
         Uorig = np.random.randn(512, 512, 3)
         rows, cols, colors = Uorig.shape
         known = np.zeros((rows, cols, colors))


### PR DESCRIPTION
## What

Most benchmark setups already call `np.random.seed`, but six did not: the four `matrix_stuffing` classes, `TvInpainting`, and `UnconstrainedQP`. This adds `np.random.seed(0)` to each.

## Why

`asv continuous` runs the base and HEAD commits in **separate processes**, each calling `setup()` independently. With unseeded RNG those two runs build problems from *different* random inputs, so the reported base-vs-HEAD ratio mixes a code change with an input change — a confound in the regression signal. Seeding makes both sides compile the identical problem, and makes the published master trend comparable across commits over time.

Compile time is mostly structure-determined, so the timing effect is usually small — but removing the confound is free and makes a flagged regression mean a code regression.

## Companion PR

Pairs with cvxpy/actions#27, which drops `--quick` from the PR gate and samples with statistics (the primary variance fix). Independent — no merge-order dependency.

## Verification
- `ruff check` passes on the changed files.
- The seeded setups compile, and two fresh `setup()` calls now produce identical inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)